### PR TITLE
retries-option: patch the parameter storing

### DIFF
--- a/rdp-sec-check.pl
+++ b/rdp-sec-check.pl
@@ -128,7 +128,7 @@ my $result = GetOptions (
          "file=s"    => \$hostfile,
          "outfile=s" => \$outfile,
          "timeout=i" => \$global_recv_timeout,
-         "retries=i" => \$global_connection_count,
+         "retries=i" => \$global_connect_fail_count,
 );
 
 if ($help) {


### PR DESCRIPTION
The retries parameter from the command line was stored in the wrong variable.
The the option works fine.