### PR TITLE
Declare '%config' within 'scan_host' function to clear hash between loops

### DIFF
--- a/rdp-sec-check.pl
+++ b/rdp-sec-check.pl
@@ -215,6 +215,7 @@ sub scan_host {
 	print "[+] Connecting to $ip:$port\n" if $debug > 1;
 	my $socket;
 	my @response;
+	my %config;
 
 	print "[+] Checking supported protocols\n\n";
 	$socket = get_socket($ip, $port);


### PR DESCRIPTION
When referencing a file containing multiple targets, the results are inaccurate due to the *config* variable not being cleared between loops. Declare the variable at the beginning of the function will prevent this.